### PR TITLE
Fix missing return type (SF6.3 deprecation)

### DIFF
--- a/FOSRestBundle.php
+++ b/FOSRestBundle.php
@@ -32,7 +32,7 @@ class FOSRestBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new SerializerConfigurationPass());
         $container->addCompilerPass(new ConfigurationCheckPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);


### PR DESCRIPTION
Fix for Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "FOS\RestBundle\FOSRestBundle" now to avoid errors or add an explicit @return annotation to suppress this message.